### PR TITLE
mobile device handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,8 @@
 <html>
 <head>
   <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
   <!-- Material Design fonts -->
   <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700">
   <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/icon?family=Material+Icons">


### PR DESCRIPTION
Dear professor Ryu,
This course homepage looks really great. 
However, this page looks bad in mobile devices. 
Although the page seems to have been created as a reactive (in perspective of screen size), there was a phenomenon that the homepage seems to be supporting only the desktop in mobile devices. 
You can resolve this issue by adding a line of meta tag to the head section.
Please check this change (this pull request) if your time is available. 
If you just merge, you can expect the issue to be resolved.
Thanks.